### PR TITLE
Fixing ampersand in user datas and auth issue

### DIFF
--- a/ig.js
+++ b/ig.js
@@ -121,6 +121,11 @@ if (!window.IG) {
                 i;
 
             for (i = 0; i < pairs.length; i++) {
+                if (pairs[i].match(/\=/g) === null)
+                    pairs[i-1] += '&' + pairs[i];
+            }
+
+            for (i = 0; i < pairs.length; i++) {
                 pair = pairs[i].split('=', 2);
                 if (pair && pair[0]) {
                     object[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');


### PR DESCRIPTION
As described in this issue.  Ampersand in user datas prevent user to auth correctly.
It comes from `string.split('&')` in IG.QS.decode() method.

Fixed with:

``` js
for (i = 0; i < pairs.length; i++) {
    if (pairs[i].match(/\=/g) === null)
    pairs[i-1] += '&' + pairs[i];
}
```

[Issue on Instagram Wiki](https://github.com/Instagram/instagram-javascript-sdk/issues/3)
